### PR TITLE
SLING-6779 - The HTL compiler and Maven Plugin should warn when using potentially invalid options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling</artifactId>
-        <version>30</version>
+        <version>35</version>
         <relativePath />
     </parent>
 
@@ -50,13 +50,13 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <site.jira.version.id>12336741,12338350,12338646,12338974,12341271,12342047,12342267,12342272,12343462,
-            12343846,12344079,12344332,12344876</site.jira.version.id>
+            12343846,12344079,12344332,12344876,12345571</site.jira.version.id>
         <maven.version>3.3.9</maven.version>
         <maven.site.path>${project.artifactId}-archives/${project.artifactId}-LATEST</maven.site.path>
-        <jacoco.version>0.8.1</jacoco.version>
-        <sightly.runtime.version>1.0.0-1.4.0-SNAPSHOT</sightly.runtime.version>
-        <sightly.compiler.version>1.1.0-1.4.0-SNAPSHOT</sightly.compiler.version>
-        <sightly.compiler.java.version>1.1.0-1.4.0-SNAPSHOT</sightly.compiler.java.version>
+        <jacoco.version>0.8.3</jacoco.version>
+        <sightly.runtime.version>1.1.1-1.4.0-SNAPSHOT</sightly.runtime.version>
+        <sightly.compiler.version>1.2.0-1.4.0-SNAPSHOT</sightly.compiler.version>
+        <sightly.compiler.java.version>1.1.3-1.4.0-SNAPSHOT</sightly.compiler.java.version>
         <argLine />
     </properties>
 
@@ -96,17 +96,17 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.scripting.sightly.runtime</artifactId>
-            <version>1.1.1-1.4.0-SNAPSHOT</version>
+            <version>${sightly.runtime.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.scripting.sightly.compiler</artifactId>
-            <version>1.1.3-1.4.0-SNAPSHOT</version>
+            <version>${sightly.compiler.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.scripting.sightly.compiler.java</artifactId>
-            <version>1.1.3-1.4.0-SNAPSHOT</version>
+            <version>${sightly.compiler.java.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -114,24 +114,21 @@
             <version>2.5</version>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.5</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>${maven.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
-            <artifactId>maven-artifact</artifactId>
-            <version>${maven.version}</version>
+            <artifactId>maven-model</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>${maven.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
@@ -245,9 +242,9 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.5</version>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>3.1.11</version>
                 <configuration>
                     <effort>Max</effort>
                     <xmlOutput>true</xmlOutput>

--- a/src/main/java/org/apache/sling/maven/htl/ValidateMojo.java
+++ b/src/main/java/org/apache/sling/maven/htl/ValidateMojo.java
@@ -149,6 +149,14 @@ public class ValidateMojo extends AbstractMojo {
     @Parameter(property = "htl.skip", defaultValue = "false")
     private boolean skip;
 
+    /**
+     * Adds the provided options to the list of known expression options, so that the compiler doesn't log any warnings about them.
+     *
+     * @since 1.3.0
+     */
+    @Parameter(property = "htl.allowedExpressionOptions")
+    private Set<String> allowedExpressionOptions;
+
     private boolean hasWarnings = false;
     private boolean hasErrors = false;
     private List<File> processedFiles = Collections.emptyList();
@@ -211,11 +219,12 @@ public class ValidateMojo extends AbstractMojo {
                 processedFiles.add(new File(sourceDirectory, includedFile));
             }
             Map<File, CompilationResult> compilationResults;
+            SightlyCompiler compiler = SightlyCompiler.withKnownExpressionOptions(allowedExpressionOptions);
             if (generateJavaClasses) {
-                compilationResults = transpileHTLScriptsToJavaClasses(processedFiles, new SightlyCompiler(), new HTLJavaImportsAnalyzer
+                compilationResults = transpileHTLScriptsToJavaClasses(processedFiles, compiler, new HTLJavaImportsAnalyzer
                         (ignoreImports));
             } else {
-                compilationResults = compileHTLScripts(processedFiles, new SightlyCompiler());
+                compilationResults = compileHTLScripts(processedFiles, compiler);
             }
             for (Map.Entry<File, CompilationResult> entry : compilationResults.entrySet()) {
                 File script = entry.getKey();

--- a/src/test/resources/test-project/invalid-options.pom.xml
+++ b/src/test/resources/test-project/invalid-options.pom.xml
@@ -1,0 +1,55 @@
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.sling</groupId>
+    <artifactId>htl-maven-plugin-it-invalid-options</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>HTL Maven Plugin IT - Invalid Options</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.sling</groupId>
+                <artifactId>htl-maven-plugin</artifactId>
+                <configuration>
+                    <sourceDirectory>src/main/resources</sourceDirectory>
+                    <!-- only the invalid-options.sly file will be compiled -->
+                    <includes>
+                        <include>**/invalid-options.sly</include>
+                    </includes>
+                    <failOnWarnings>true</failOnWarnings>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>validate-scripts</id>
+                        <goals>
+                            <goal>validate</goal>
+                        </goals>
+                        <phase>compile</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/test-project/non-default-options.pom.xml
+++ b/src/test/resources/test-project/non-default-options.pom.xml
@@ -1,0 +1,59 @@
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.sling</groupId>
+    <artifactId>htl-maven-plugin-it-non-default-options</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>HTL Maven Plugin IT - Non-Default Options</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.sling</groupId>
+                <artifactId>htl-maven-plugin</artifactId>
+                <configuration>
+                    <sourceDirectory>src/main/resources</sourceDirectory>
+                    <!-- only the non-default-options.sly file will be compiled -->
+                    <includes>
+                        <include>**/non-default-options.sly</include>
+                    </includes>
+                    <allowedExpressionOptions>
+                        <allowedExpressionOption>addedToKnownOptions1</allowedExpressionOption>
+                        <allowedExpressionOption>addedToKnownOptions2</allowedExpressionOption>
+                    </allowedExpressionOptions>
+                    <failOnWarnings>true</failOnWarnings>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>validate-scripts</id>
+                        <goals>
+                            <goal>validate</goal>
+                        </goals>
+                        <phase>compile</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/test-project/src/main/resources/apps/projects/invalid-options.sly
+++ b/src/test/resources/test-project/src/main/resources/apps/projects/invalid-options.sly
@@ -1,0 +1,17 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+${'this is a text' @ invalidOption}

--- a/src/test/resources/test-project/src/main/resources/apps/projects/non-default-options.sly
+++ b/src/test/resources/test-project/src/main/resources/apps/projects/non-default-options.sly
@@ -1,0 +1,21 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+${'this is a text' @ addedToKnownOptions1}
+${'this is a text' @ addedToKnownOptions2}
+


### PR DESCRIPTION
* added all known expression and plugin options to the compiler
* added the possibility to configure the compiler to ignore certain additional options
* enhanced the HTL Script Engine to allow it to configure the compiler for additional options
* enhanced the HTL Maven Plugin to rely on a new configuration option to pass down additional
options to the compiler